### PR TITLE
feat: new resizeConstraints flags

### DIFF
--- a/src/ResizePlugin.ts
+++ b/src/ResizePlugin.ts
@@ -21,6 +21,12 @@ interface ResizePluginOption {
   locale?: Locale;
   [index: string]: any;
   keepAspectRatio?: boolean;
+  resizeConstraints?: {
+    minWidth?: number;
+    maxWidth?: number;
+    minHeight?: number;
+    maxHeight?: number;
+  };
 }
 const template = `
 <div class="handler" title="{0}"></div>
@@ -176,12 +182,32 @@ class ResizePlugin {
       height = rate * width;
     }
 
-    this.resizeTarget.style.setProperty("width", Math.max(width, 30) + "px");
+    const minWidth = this.options?.resizeConstraints?.minWidth ?? 30;
+    const minHeight = this.options?.resizeConstraints?.minHeight ?? 30;
+
+    if (width < minWidth) {
+      width = minWidth;
+    }
+    if (
+      this.options?.resizeConstraints?.maxWidth !== undefined &&
+      width > this.options.resizeConstraints.maxWidth
+    ) {
+      width = this.options.resizeConstraints.maxWidth;
+    }
+
+    if (height < minHeight) {
+      height = minHeight;
+    }
+    if (
+      this.options?.resizeConstraints?.maxHeight !== undefined &&
+      height > this.options.resizeConstraints.maxHeight
+    ) {
+      height = this.options.resizeConstraints.maxHeight;
+    }
+    this.resizeTarget.style.setProperty("width", width + "px");
+
     if (!this.options?.keepAspectRatio) {
-      this.resizeTarget.style.setProperty(
-        "height",
-        Math.max(height, 30) + "px"
-      );
+      this.resizeTarget.style.setProperty("height", height + "px");
     }
     this.positionResizerToTarget(this.resizeTarget);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,12 @@ interface QuillResizeImageOptions {
     disableIframes?: boolean;
   };
   keepAspectRatio?: boolean;
+  resizeConstraints?: {
+    minWidth?: number;
+    maxWidth?: number;
+    minHeight?: number;
+    maxHeight?: number;
+  };
 }
 
 function QuillResizeImage(quill: Quill, options?: QuillResizeImageOptions) {


### PR DESCRIPTION
This flag is a new option to add to the options list. It adds the possibility to set a min/max width/height value to the resize action. 

This will allow the dev to prevent users to customize the minimal and maximal value of the resizing (previously the default min values were 30).

Note that using this with `keepAspectRatio` set to true will only use the min max of the width.

Also this will not apply when using the % format of the resize.